### PR TITLE
Fix "Looper.prepare()" during first authentication issue. 

### DIFF
--- a/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/wrappers/UserWrapper.java
+++ b/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/wrappers/UserWrapper.java
@@ -17,6 +17,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.ServerValue;
 import com.google.firebase.database.ValueEventListener;
 
+import io.reactivex.android.schedulers.AndroidSchedulers;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
@@ -175,7 +176,7 @@ public class UserWrapper {
                 e.onComplete();
             }));
 
-        }).subscribeOn(Schedulers.single());
+        }).subscribeOn(AndroidSchedulers.mainThread());
     }
 
     public Observable<User> metaOn() {


### PR DESCRIPTION
Fix "Can't create handler inside thread that has not called Looper.prepare()" during first ChatSDK authentication issue.

Issue was reproducing only during the first authentication after app install. All next authentications works normally. 

Here is the full stack trace with issue: 
`
W/System.err: java.lang.RuntimeException: Can't create handler inside thread that has not called Looper.prepare()
        at android.os.Handler.<init>(Handler.java:200)
        at android.os.Handler.<init>(Handler.java:114)
        at com.google.firebase.database.zza.<init>(com.google.firebase:firebase-database@@16.0.2:1024)
        at com.google.firebase.database.obfuscated.zzb.zza(com.google.firebase:firebase-database@@16.0.2:77)
        at com.google.firebase.database.obfuscated.zzu.zza(com.google.firebase:firebase-database@@16.0.2:2234)
        at com.google.firebase.database.obfuscated.zzad.zzb(com.google.firebase:firebase-database@@16.0.2:92)
        at com.google.firebase.database.obfuscated.zzad.zza(com.google.firebase:firebase-database@@16.0.2:42)
        at com.google.firebase.database.FirebaseDatabase.zza(com.google.firebase:firebase-database@@16.0.2:357)
        at com.google.firebase.database.FirebaseDatabase.getReference(com.google.firebase:firebase-database@@16.0.2:188)
        at co.chatsdk.firebase.FirebasePaths.firebaseRawRef(FirebasePaths.java:41)
        at co.chatsdk.firebase.FirebasePaths.firebaseRef(FirebasePaths.java:45)
W/System.err:     at co.chatsdk.firebase.FirebasePaths.usersRef(FirebasePaths.java:51)
        at co.chatsdk.firebase.FirebasePaths.userRef(FirebasePaths.java:56)
        at co.chatsdk.firebase.wrappers.UserWrapper.ref(UserWrapper.java:324)
        at co.chatsdk.firebase.wrappers.UserWrapper.lambda$once$1(UserWrapper.java:169)
        at co.chatsdk.firebase.wrappers.-$$Lambda$UserWrapper$idbQrKLfae1VwyX0e4DBgdkgNrQ.subscribe(lambda)
        at io.reactivex.internal.operators.completable.CompletableCreate.subscribeActual(CompletableCreate.java:39)
        at io.reactivex.Completable.subscribe(Completable.java:1918)
        at io.reactivex.internal.operators.completable.CompletableSubscribeOn$SubscribeOnObserver.run(CompletableSubscribeOn.java:64)
        at io.reactivex.internal.schedulers.ScheduledDirectTask.call(ScheduledDirectTask.java:38)
        at io.reactivex.internal.schedulers.ScheduledDirectTask.call(ScheduledDirectTask.java:26)
        at java.util.concurrent.FutureTask.run(FutureTask.java:237)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:269)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
        at java.lang.Thread.run(Thread.java:818)
`

And question on StackOverflow with similar issue: https://stackoverflow.com/q/52369719