### PR TITLE
When looking for threads between two users, Android ChatSDK should also so look for the empty ones (like the iOS version).

### DIFF
--- a/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
+++ b/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
@@ -189,7 +189,7 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
 
                 // Check to see if a thread already exists with these
                 // two users
-                for(Thread thread : getThreads(ThreadType.Private1to1, true)) {
+                for(Thread thread : getThreads(ThreadType.Private1to1, true, true)) {
                     if(thread.getUsers().size() == 2 &&
                             thread.getUsers().contains(currentUser) &&
                             thread.getUsers().contains(otherUser))


### PR DESCRIPTION
When looking for threads between two users, Android ChatSDK should also so look for the empty ones (like the iOS version).

Otherwise, when one creates a thread but writes nothing, database is flooded with empty threads. One thing to consider here: If your ChatSDK database is already flooded with empty threads, it is best to clean them up before upgrading, as after this update, getThread function may retrieve one of them instead of the actively used one.

A tiny piece of code to clean up empty threads on login will also eliminate any problems that may occur with this commit.