### PR TITLE
Update delete button to also add contacts

### DIFF
--- a/chat-sdk-core/src/main/res/values/strings.xml
+++ b/chat-sdk-core/src/main/res/values/strings.xml
@@ -20,7 +20,8 @@
     <string name="password">Password</string>
     <string name="logout">Logout</string>
     <string name="search">Search</string>
-    <string name="add_contacts">Add Contacts</string>
+    <string name="add_contacts">Add to Contacts</string>
+    <string name="delete_contact">Remove Contact</string>
     <string name="add_users">Add Users</string>
     <string name="start_chat">Start Chat</string>
     <string name="contacts_upper_case">CONTACTS</string>
@@ -223,6 +224,8 @@
     <string name="block">Block</string>
     <string name="blocked">Blocked</string>
     <string name="unblock">Unblock</string>
+    <string name="contact_deleted">Contact deleted</string>
+    <string name="contact_added">Contact added</string>
     <string name="user_blocked">User blocked</string>
     <string name="user_unblocked">User unblocked</string>
     <string name="user_deleted">User deleted</string>

--- a/chat-sdk-ui/src/main/res/layout/chat_sdk_profile_fragment.xml
+++ b/chat-sdk-ui/src/main/res/layout/chat_sdk_profile_fragment.xml
@@ -187,7 +187,7 @@
             app:layout_constraintTop_toBottomOf="@+id/tvFollows" />
 
         <Button
-            android:id="@+id/btnBlock"
+            android:id="@+id/btnBlockOrUnblock"
             android:layout_width="0dp"
             android:layout_height="36dp"
             android:layout_marginLeft="8dp"
@@ -199,16 +199,16 @@
             app:layout_constraintTop_toBottomOf="@+id/tvFollowed" />
 
         <Button
-            android:id="@+id/btnDelete"
+            android:id="@+id/btnAddOrDelete"
             android:layout_width="0dp"
             android:layout_height="36dp"
             android:layout_marginLeft="8dp"
-            android:layout_marginRight="8dp"
             android:layout_marginTop="8dp"
-            android:text="@string/delete"
+            android:layout_marginRight="8dp"
+            android:text="@string/add_contacts"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btnBlock" />
+            app:layout_constraintTop_toBottomOf="@+id/btnBlockOrUnblock" />
 
         <ImageView
             android:id="@+id/ivAvailability"


### PR DESCRIPTION
### Changes
The previously called `Delete` button on a contact's profile screen will now have the title `Add to Contacts` in case the user is not already in your contacts list and `Remove Contact` in case the user is already in your contacts list and it will also function the way the title says.

### Reason for changes
I was able view a user's profile from a group chat without having the user in my contacts list and the button was still saying `Delete` which didn't make sense.