### PR TITLE
ChatActivity not showing the expected actionbar text/avatar on a new thread

### DIFF
--- a/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
+++ b/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
@@ -235,7 +235,7 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
             else {
                 e.onSuccess(thread);
             }
-        })).doOnSuccess(thread -> thread.addUser(ChatSDK.currentUser())).subscribeOn(Schedulers.single());
+        })).doOnSuccess(thread -> thread.addUsers(users)).subscribeOn(Schedulers.single());
     }
 
     public Completable deleteThread(Thread thread) {


### PR DESCRIPTION
### The problem
We have seen a flaky behaviour with the `ChatActivity` action bar, just after the Thread creation.

Seems that the [`ChatActivity#initActionBar`](https://github.com/chat-sdk/chat-sdk-android/blob/49e80d213b2ea0d2c979276daf1d4261c0e0d2f9/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/ChatActivity.java#L187) can happen before the `ChildEventListener` registered in [`ThreadWrapper#usersOn`](https://github.com/chat-sdk/chat-sdk-android/blob/5e39b8770d004ac2e6138eb57c49eac068121d45/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/wrappers/ThreadWrapper.java#L362) to the user's threads notice that a new thread has been created, and some users have been added to it.

As result, the behaviour of `Strings.nameForThread(thread)` and `ThreadImageBuilder.load(circleImageView, thread)` is not the expected one, as they resolve the current user as the only member in the thread. This is because the `UserThreadLink` for only the current user is created during the thread creation in [`FirebaseThreadHandler#createThread`](https://github.com/chat-sdk/chat-sdk-android/blob/1ef8c96b442185f9156accfcc65f69f75f1785ec/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java#L238).  

### Proposed solution
Create the expected `UserThreadLink` entities for the known members during the thread creation.