### PR TITLE
Fix SecurityException for missing ContentProvider with API > 25

### DIFF
--- a/chat-sdk-ui/src/main/AndroidManifest.xml
+++ b/chat-sdk-ui/src/main/AndroidManifest.xml
@@ -24,6 +24,12 @@
             <!--</meta-data>-->
         <!--</provider>-->
 
+        <provider
+            android:name=".chat.PhotoProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true" />
+
         <activity android:name=".login.LoginActivity"
             android:screenOrientation="portrait"
             android:theme="@style/SdkTheme">

--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/MediaSelector.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/MediaSelector.java
@@ -51,7 +51,7 @@ public class MediaSelector {
         Context context = ChatSDK.shared().context();
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         File destination = ImageUtils.createEmptyFileInCacheDirectory(context, "CAPTURE", ".jpg");
-        fileUri = Uri.fromFile(destination);
+        fileUri = PhotoProvider.getPhotoUri(destination, context);
         intent.putExtra(MediaStore.EXTRA_OUTPUT, fileUri);
 
         if (intent.resolveActivity(activity.getPackageManager()) != null) {

--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/PhotoProvider.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/PhotoProvider.java
@@ -1,0 +1,65 @@
+package co.chatsdk.ui.chat;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.io.File;
+
+public class PhotoProvider extends ContentProvider {
+
+    private static final String CONTENT_PROVIDER_AUTHORITY_SUFFIX = ".provider";
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection, @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    public static Uri getPhotoUri(File file, Context context) {
+        Uri fileUri = Uri.fromFile(file);
+        Uri.Builder builder = new Uri.Builder()
+                .authority(getContentProviderAuthority(context))
+                .scheme("file")
+                .path(fileUri.getPath())
+                .query(fileUri.getQuery())
+                .fragment(fileUri.getFragment());
+
+        return builder.build();
+    }
+
+    private static String getContentProviderAuthority(Context context){
+        return context.getPackageName() + CONTENT_PROVIDER_AUTHORITY_SUFFIX;
+    }
+}


### PR DESCRIPTION
In our chatsdk we have found an issue related with the compatibility with **API > 25**. This issue can be reproduced in chat-sdk if you upgrade the target SDK version to >25.

This issue is related to the usage of `ContentResolver.notifyChange()` in [MediaSelector#handleResult](https://github.com/chat-sdk/chat-sdk-android/blob/572ff147f5a83103e86da16dc5d05bacd108efa6/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/MediaSelector.java#L179) in **for API > 25**.

When the `MediaSelector` tries to load a picture from the camera, it crashes with:
```
java.lang.SecurityException: Failed to find provider for user 0; expected to find a valid ContentProvider for this authority
```
As [Android documentation](https://developer.android.com/about/versions/oreo/android-8.0-changes#ccn) says:

> Android 8.0 (API level 26) changes how `ContentResolver.notifyChange()` and `registerContentObserver(Uri, boolean, ContentObserver)` behave for apps targeting Android 8.0.
> These APIs now require that a valid ContentProvider is defined for the authority in all Uris. Defining a valid ContentProvider with relevant permissions will help defend your app against content changes from malicious apps, and prevent you from leaking potentially private data to malicious apps.

Inspired by the solution proposed in ["Fixing SecurityException requiring a valid ContentProvider on Android 8"](https://medium.com/@egemenhamutcu/fixing-securityexception-requiring-a-valid-contentprovider-on-android-8-1110d840522) we have created and authorised the `PhotoProvider`.