### PR TITLE
On failure with Google social login, we show a message `null`

### DIFF
--- a/chat-sdk-firebase-social-login/src/main/java/co/chatsdk/firebase/social_login/FirebaseSocialLoginHandler.java
+++ b/chat-sdk-firebase-social-login/src/main/java/co/chatsdk/firebase/social_login/FirebaseSocialLoginHandler.java
@@ -151,7 +151,7 @@ public class FirebaseSocialLoginHandler implements SocialLoginHandler {
                     e.onSuccess(credential);
                 }
                 else {
-                    e.onError(new Exception(result.getStatus().getStatusMessage()));
+                    e.onError(new Exception(result.getStatus().toString()));
                 }
             };
 


### PR DESCRIPTION
On an error in ['FirebaseSocialLoginHandler#loginWithGoogle'](https://github.com/chat-sdk/chat-sdk-android/blob/ee0dd085559e9a140db76015aff41172ed40ff37/chat-sdk-firebase-social-login/src/main/java/co/chatsdk/firebase/social_login/FirebaseSocialLoginHandler.java#L154), we wrap the `Status#getStatusMessage` in an exception to be thrown.

The problem is that `Status#getStatusMessage` is null for few scenarios (check `com.google.android.gms.common.api.Status` static instances).

As fix we propose to make use of the `Status#toString` implementation.