### PR TITLE
Read receipts are saved to the local database with the same primary key

### DIFF
--- a/chat-sdk-core/src/main/java/co/chatsdk/core/dao/Message.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/dao/Message.java
@@ -254,6 +254,7 @@ public class Message implements CoreEntity {
         ReadReceiptUserLink link = linkForUser(user);
         if(link == null) {
             link = StorageManager.shared().createEntity(ReadReceiptUserLink.class);
+            link.setReadReceiptId(this.getId());
             readReceiptLinks.add(link);
             update();
         }

--- a/chat-sdk-core/src/main/java/co/chatsdk/core/dao/ReadReceiptUserLink.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/dao/ReadReceiptUserLink.java
@@ -20,7 +20,7 @@ import co.chatsdk.core.utils.DaoDateTimeConverter;
 public class ReadReceiptUserLink implements CoreEntity {
 
     @Id
-    private long id;
+    private Long id;
 
     private long readReceiptId;
     private long userId;
@@ -41,7 +41,7 @@ public class ReadReceiptUserLink implements CoreEntity {
     private transient ReadReceiptUserLinkDao myDao;
 
     @Generated(hash = 305755340)
-    public ReadReceiptUserLink(long id, long readReceiptId, long userId, int status, DateTime date) {
+    public ReadReceiptUserLink(Long id, long readReceiptId, long userId, int status, DateTime date) {
         this.id = id;
         this.readReceiptId = readReceiptId;
         this.userId = userId;
@@ -53,7 +53,7 @@ public class ReadReceiptUserLink implements CoreEntity {
     public ReadReceiptUserLink() {
     }
 
-    public long getId() {
+    public Long getId() {
         return this.id;
     }
 
@@ -182,5 +182,8 @@ public class ReadReceiptUserLink implements CoreEntity {
         this.date = date;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
 
 }

--- a/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
+++ b/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
@@ -189,7 +189,7 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
 
                 // Check to see if a thread already exists with these
                 // two users
-                for(Thread thread : getThreads(ThreadType.Private1to1, true)) {
+                for(Thread thread : getThreads(ThreadType.Private1to1, true, true)) {
                     if(thread.getUsers().size() == 2 &&
                             thread.getUsers().contains(currentUser) &&
                             thread.getUsers().contains(otherUser))

--- a/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
+++ b/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
@@ -189,7 +189,7 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
 
                 // Check to see if a thread already exists with these
                 // two users
-                for(Thread thread : getThreads(ThreadType.Private1to1, true, true)) {
+                for(Thread thread : getThreads(ThreadType.Private1to1, true)) {
                     if(thread.getUsers().size() == 2 &&
                             thread.getUsers().contains(currentUser) &&
                             thread.getUsers().contains(otherUser))


### PR DESCRIPTION
Read receipts are saved to the local database with the same primary key (_id = 0). It is OK if you don't reinstall the app, as there is another column for messages in the database for "read" flag, but when reinstalling the app, the messages are redownloaded from Firebase and the read flags are not set correctly.

This is because the CoreEntity for ReadReceiptUserLink is created with a primary key of "long" (primitive) not "Long" (class). 

When it is created with "long" instead of "Long", greenDAO generates the Dao DDL with "\"_id\" INTEGER PRIMARY KEY NOT NULL. I am no SQLite expert but have lots of experience with enterprise level databases, in which normally NOT NULL makes sense for a PRIMARY KEY.

I don't know if this is a bug (or feature) of SQLite or greendao, but when _id is created with NOT NULL statement in SQLite, it is not mapped to the internal autoincrement ROWID, therefore always stays 0. All read receipts are inserted into the same row with the id 0. I checked this (after late night hair pulling for a couple of hours) by injecting a counter into readReceiptId and afterwards downloading the sqlite database to my computer.

Long story short, changing the primitive long to class Long, the table is generated correctly.

I also had to set readReceiptId to the Message's Id manually. I would expect an automatic assignment from greendao, but it did not work that way.

Now, I can remove the app and install again, the "read" status of messages are persisted.