### PR TITLE
Using AppCompatImageButton and imageResource instead of ImageButton and background resource in chat message box

### DIFF
--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/TextInputView.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/TextInputView.java
@@ -259,11 +259,11 @@ public class TextInputView extends LinearLayout implements View.OnKeyListener, T
 
     public void updateSendButton () {
         if(StringChecker.isNullOrEmpty(getMessageText()) && audioModeEnabled) {
-            btnSend.setBackgroundResource(R.drawable.ic_36_mic);
+            btnSend.setImageResource(R.drawable.ic_36_mic);
             recordOnPress = true;
         }
         else {
-            btnSend.setBackgroundResource(R.drawable.ic_36_send);
+            btnSend.setImageResource(R.drawable.ic_36_send);
             recordOnPress = false;
         }
     }

--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/TextInputView.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/TextInputView.java
@@ -12,6 +12,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.graphics.Rect;
+import android.support.v7.widget.AppCompatImageButton;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -42,7 +43,7 @@ import io.reactivex.disposables.Disposable;
 
 public class TextInputView extends LinearLayout implements View.OnKeyListener, TextView.OnEditorActionListener{
 
-    protected ImageButton btnSend;
+    protected AppCompatImageButton btnSend;
     protected ImageButton btnOptions;
     protected EditText etMessage;
     protected boolean audioModeEnabled = false;

--- a/chat-sdk-ui/src/main/res/layout/chat_sdk_view_message_box.xml
+++ b/chat-sdk-ui/src/main/res/layout/chat_sdk_view_message_box.xml
@@ -10,7 +10,8 @@
     <ImageButton
         android:layout_width="36dp"
         android:layout_height="36dp"
-        android:background="@drawable/ic_options"
+        android:src="@drawable/ic_options"
+        android:background="?attr/selectableItemBackgroundBorderless"
         android:layout_gravity="bottom"
         android:id="@+id/chat_sdk_btn_options"
         android:layout_margin="10dp"
@@ -36,7 +37,8 @@
     <ImageButton
         android:layout_width="36dp"
         android:layout_height="36dp"
-        android:background="@drawable/ic_36_mic"
+        android:src="@drawable/ic_36_mic"
+        android:background="?attr/selectableItemBackgroundBorderless"
         android:gravity="center"
         android:layout_margin="10dp"
         android:layout_gravity="bottom"


### PR DESCRIPTION
To be able to load vectorial drawables as the send button in the chat (and be able to override it by using our resources folders), I prepared this PR to change it from ImageButton to AppCompatImageButton.

Also, by using the imageResource instead of the background, we can add the background selectableItemBackgroundBorderless to have a nice material ripple effect :)

Hope it works fine! 💃 