### PR TITLE
Prevent duplicate empty threads

### DIFF
--- a/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
+++ b/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
@@ -189,7 +189,7 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
 
                 // Check to see if a thread already exists with these
                 // two users
-                for(Thread thread : getThreads(ThreadType.Private1to1, true)) {
+                for(Thread thread : getThreads(ThreadType.Private1to1, true, true)) {
                     if(thread.getUsers().size() == 2 &&
                             thread.getUsers().contains(currentUser) &&
                             thread.getUsers().contains(otherUser))


### PR DESCRIPTION
Previously, if `showEmptyChats` was false, a new thread would be created each time you open a new chat with a user if existing threads are empty. When checking for existing threads, it should include existing empty chats regardless of the `showEmptyChats` setting, to avoid duplicates.