### PR TITLE
 Create new thread if existing private thread has been deleted by user

### DIFF
--- a/chat-sdk-core/src/main/java/co/chatsdk/core/session/Configuration.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/session/Configuration.java
@@ -42,6 +42,9 @@ public class Configuration {
     public String firebaseDatabaseUrl;
     public String firebaseStorageUrl;
 
+    // TODO: expose in builder when reuse is supported
+    public boolean reuseDeletedThreads = false;
+
     // Should we call disconnect when the app is in the background for more than 5 seconds?
     public boolean disconnectFromFirebaseWhenInBackground = true;
 

--- a/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
+++ b/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
@@ -36,9 +36,9 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
     public static int UserThreadLinkTypeAddUser = 1;
     public static int UserThreadLinkTypeRemoveUser = 2;
 
-    public Single<List<Message>> loadMoreMessagesForThread(final Message fromMessage,final Thread thread) {
+    public Single<List<Message>> loadMoreMessagesForThread(final Message fromMessage, final Thread thread) {
         return super.loadMoreMessagesForThread(fromMessage, thread).flatMap(messages -> {
-            if(messages.isEmpty()) {
+            if (messages.isEmpty()) {
                 return new ThreadWrapper(thread).loadMoreMessages(fromMessage, ChatSDK.config().messagesToLoadPerBatch);
             }
             return Single.just(messages);
@@ -61,6 +61,7 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
      * path with the user IDs. And add the thread ID to the user/threads path for
      * private threads. If value is null, the users will be removed from the thread/users
      * path and the thread will be removed from the user/threads path
+     *
      * @param thread
      * @param users
      * @param userThreadLinkType - 1 => Add, 2 => Remove
@@ -81,15 +82,14 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
                 String userThreadsPath = userThreadsRef.toString().replace(userThreadsRef.getRoot().toString(), "");
 
                 //
-                if(userThreadLinkType == UserThreadLinkTypeAddUser) {
+                if (userThreadLinkType == UserThreadLinkTypeAddUser) {
                     data.put(threadUsersPath, u.getEntityID().equals(thread.getCreatorEntityId()) ? Keys.Owner : Keys.Member);
                     data.put(userThreadsPath, ChatSDK.currentUser().getEntityID());
 
                     if (thread.typeIs(ThreadType.Public)) {
                         threadUsersRef.onDisconnect().removeValue();
                     }
-                }
-                else if (userThreadLinkType == UserThreadLinkTypeRemoveUser) {
+                } else if (userThreadLinkType == UserThreadLinkTypeRemoveUser) {
                     data.put(threadUsersPath, null);
                     data.put(userThreadsPath, null);
                 }
@@ -98,7 +98,7 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
             ref.updateChildren(data, (databaseError, databaseReference) -> {
                 if (databaseError == null) {
                     FirebaseEntity.pushThreadUsersUpdated(thread.getEntityID()).subscribe(new CrashReportingCompletableObserver());
-                    for(User u : users) {
+                    for (User u : users) {
                         FirebaseEntity.pushUserThreadsUpdated(u.getEntityID()).subscribe(new CrashReportingCompletableObserver());
                     }
                     e.onComplete();
@@ -121,11 +121,13 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
         return new ThreadWrapper(thread).pushMeta();
     }
 
-    /** Send a message,
-     *  The message need to have a owner thread attached to it or it cant be added.
-     *  If the destination thread is public the system will add the user to the message thread if needed.
-     *  The uploading to the server part can bee seen her {@see FirebaseCoreAdapter#PushMessageWithComplition}.*/
-    public Observable<MessageSendProgress> sendMessage(final Message message){
+    /**
+     * Send a message,
+     * The message need to have a owner thread attached to it or it cant be added.
+     * If the destination thread is public the system will add the user to the message thread if needed.
+     * The uploading to the server part can bee seen her {@see FirebaseCoreAdapter#PushMessageWithComplition}.
+     */
+    public Observable<MessageSendProgress> sendMessage(final Message message) {
         return Observable.create(e -> new MessageWrapper(message).send()
                 .subscribeOn(Schedulers.single())
                 .subscribe(() -> {
@@ -137,11 +139,11 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
 
     /**
      * Create thread for given users.
-     *  When the thread is added to the server the "onMainFinished" will be invoked,
-     *  If an error occurred the error object would not be null.
-     *  For each user that was successfully added the "onItem" method will be called,
-     *  For any item adding failure the "onItemFailed will be called.
-     *   If the main task will fail the error object in the "onMainFinished" method will be called."
+     * When the thread is added to the server the "onMainFinished" will be invoked,
+     * If an error occurred the error object would not be null.
+     * For each user that was successfully added the "onItem" method will be called,
+     * For any item adding failure the "onItemFailed will be called.
+     * If the main task will fail the error object in the "onMainFinished" method will be called."
      **/
     public Single<Thread> createThread(final List<User> users) {
         return createThread(null, users);
@@ -155,7 +157,7 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
         return createThread(name, users, type, null);
     }
 
-     public Single<Thread> createThread(String name, List<User> users, int type, String entityID) {
+    public Single<Thread> createThread(String name, List<User> users, int type, String entityID) {
         return Single.create((SingleOnSubscribe<Thread>) e -> {
 
             // If the entity ID is set, see if the thread exists and return it if it does
@@ -170,18 +172,18 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
 
             User currentUser = ChatSDK.currentUser();
 
-            if(!users.contains(currentUser)) {
+            if (!users.contains(currentUser)) {
                 users.add(currentUser);
             }
 
 
-            if(users.size() == 2 && (type == -1 || type == ThreadType.Private1to1)) {
+            if (users.size() == 2 && (type == -1 || type == ThreadType.Private1to1)) {
 
                 User otherUser = null;
                 Thread jointThread = null;
 
-                for(User user : users) {
-                    if(!user.equals(currentUser)) {
+                for (User user : users) {
+                    if (!user.equals(currentUser)) {
                         otherUser = user;
                         break;
                     }
@@ -189,17 +191,16 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
 
                 // Check to see if a thread already exists with these
                 // two users
-                for(Thread thread : getThreads(ThreadType.Private1to1, true, true)) {
-                    if(thread.getUsers().size() == 2 &&
+                for (Thread thread : getThreads(ThreadType.Private1to1, true, true)) {
+                    if (thread.getUsers().size() == 2 &&
                             thread.getUsers().contains(currentUser) &&
-                            thread.getUsers().contains(otherUser))
-                    {
+                            thread.getUsers().contains(otherUser)) {
                         jointThread = thread;
                         break;
                     }
                 }
 
-                if(jointThread != null) {
+                if (jointThread != null) {
                     jointThread.setDeleted(false);
                     DaoCore.updateEntity(jointThread);
                     e.onSuccess(jointThread);
@@ -215,10 +216,9 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
             thread.setCreationDate(new Date());
             thread.setName(name);
 
-            if(type != -1) {
+            if (type != -1) {
                 thread.setType(type);
-            }
-            else {
+            } else {
                 thread.setType(users.size() == 2 ? ThreadType.Private1to1 : ThreadType.PrivateGroup);
             }
 
@@ -226,13 +226,12 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
             e.onSuccess(thread);
 
         }).flatMap((Function<Thread, SingleSource<? extends Thread>>) thread -> Single.create(e -> {
-            if(thread.getEntityID() == null) {
+            if (thread.getEntityID() == null) {
                 ThreadWrapper wrapper = new ThreadWrapper(thread);
 
                 wrapper.push().concatWith(addUsersToThread(thread, users)).subscribe(() -> e.onSuccess(thread), e::onError);
 
-            }
-            else {
+            } else {
                 e.onSuccess(thread);
             }
         })).doOnSuccess(thread -> thread.addUser(ChatSDK.currentUser())).subscribeOn(Schedulers.single());
@@ -249,7 +248,7 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
         }).flatMapCompletable(thread -> new ThreadWrapper(thread).deleteThread()).subscribeOn(Schedulers.single());
     }
 
-    protected void pushForMessage(final Message message){
+    protected void pushForMessage(final Message message) {
         if (ChatSDK.push() == null) {
             return;
         }
@@ -259,15 +258,15 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
         }
     }
 
-    public Completable deleteMessage (Message message) {
+    public Completable deleteMessage(Message message) {
         return new MessageWrapper(message).delete();
     }
 
-    public Completable leaveThread (Thread thread) {
+    public Completable leaveThread(Thread thread) {
         return null;
     }
 
-    public Completable joinThread (Thread thread) {
+    public Completable joinThread(Thread thread) {
         return null;
     }
 


### PR DESCRIPTION
Temporary workaround for not being able to open threads at all if an existing private thread has been deleted.

Formatted according to android style guide in separate commit.
I will likely submit many PRs in the future, and use auto format with android style guides a lot.
I hope this isn't an issue. If it is, can you please provide a style configuration for the style you use in the project?

Fix #424 
