### PR TITLE
Changed send button from ImageButton to AppCompatImageButton

### DIFF
--- a/chat-sdk-ui/src/main/res/layout/chat_sdk_view_message_box.xml
+++ b/chat-sdk-ui/src/main/res/layout/chat_sdk_view_message_box.xml
@@ -34,7 +34,7 @@
             android:inputType="textShortMessage|textMultiLine"/>
     </FrameLayout>
 
-    <ImageButton
+    <AppCompatImageButton
         android:layout_width="36dp"
         android:layout_height="36dp"
         android:src="@drawable/ic_36_mic"


### PR DESCRIPTION
We realised because of lint, that this ImageButton in chat_sdk_view_message_box.xml should've been an AppCompatImageButton.

Thanks!!