### PR TITLE
Added reusePrivate1to1Threads configuration

### DIFF
--- a/chat-sdk-core/src/main/java/co/chatsdk/core/session/Configuration.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/session/Configuration.java
@@ -93,6 +93,7 @@ public class Configuration {
     public boolean threadDetailsEnabled = true;
     public boolean publicRoomCreationEnabled = false;
     public boolean saveImagesToDirectory = false;
+    public boolean reusePrivate1to1Threads = true;
 
     public int messageColorMe = Color.parseColor("#b0cfea");
     public int messageColorReply = Color.parseColor("#dadada");
@@ -463,6 +464,11 @@ public class Configuration {
 
         public Builder saveImagesToDirectoryEnabled (boolean value) {
             config.saveImagesToDirectory = value;
+            return this;
+        }
+
+        public Builder reusePrivate1to1ThreadsEnabled(boolean value) {
+            config.reusePrivate1to1Threads = value;
             return this;
         }
 

--- a/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
+++ b/chat-sdk-firebase-adapter/src/main/java/co/chatsdk/firebase/FirebaseThreadHandler.java
@@ -26,6 +26,7 @@ import io.reactivex.SingleOnSubscribe;
 import io.reactivex.SingleSource;
 import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
+import timber.log.Timber;
 
 /**
  * Created by benjaminsmiley-andrews on 25/05/2017.
@@ -187,23 +188,24 @@ public class FirebaseThreadHandler extends AbstractThreadHandler {
                     }
                 }
 
-                // Check to see if a thread already exists with these
-                // two users
-                for(Thread thread : getThreads(ThreadType.Private1to1, true)) {
-                    if(thread.getUsers().size() == 2 &&
-                            thread.getUsers().contains(currentUser) &&
-                            thread.getUsers().contains(otherUser))
-                    {
-                        jointThread = thread;
-                        break;
+                if (ChatSDK.config().reusePrivate1to1Threads) {
+                    // Check to see if a thread already exists with these
+                    // two users
+                    for (Thread thread : getThreads(ThreadType.Private1to1, true)) {
+                        if (thread.getUsers().size() == 2 &&
+                                thread.getUsers().contains(currentUser) &&
+                                thread.getUsers().contains(otherUser)) {
+                            jointThread = thread;
+                            break;
+                        }
                     }
-                }
 
-                if(jointThread != null) {
-                    jointThread.setDeleted(false);
-                    DaoCore.updateEntity(jointThread);
-                    e.onSuccess(jointThread);
-                    return;
+                    if (jointThread != null) {
+                        jointThread.setDeleted(false);
+                        DaoCore.updateEntity(jointThread);
+                        e.onSuccess(jointThread);
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
Because we need to save different threads between two users (as having different historical chats), in order to be able to create a new thread between two users that already had a thread, we added a configuration flag to allow us to not return the "jointThread" in FirebaseThreadHandler.

Maybe there's another way of achieving this, but right now, this was the best way we thought to fulfill our needs without altering the normal behaviour of ChatSDK.

Very much open to any best approach or any feedback given.

Thanks in advance!