### PR TITLE
Fix thread not updating when coming from another thread's push.

### DIFF
--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/ChatActivity.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/ChatActivity.java
@@ -348,11 +348,33 @@ public class ChatActivity extends BaseActivity implements TextInputDelegate, Cha
         return layoutManager;
     }
 
+    protected void setSubtitleText(String text) {
+        if(StringChecker.isNullOrEmpty(text)) {
+            if(thread.typeIs(ThreadType.Private1to1)) {
+                text = getString(R.string.tap_here_for_contact_info);
+            }
+            else {
+                text = "";
+                for(User u : thread.getUsers()) {
+                    if(!u.isMe()) {
+                        String name = u.getName();
+                        if (name != null && name.length() > 0) {
+                            text += name + ", ";
+                        }
+                    }
+                }
+                if(text.length() > 0) {
+                    text = text.substring(0, text.length() - 2);
+                }
+            }
+        }
+        final String finalText = text;
+        new Handler(getMainLooper()).post(() -> subtitleTextView.setText(finalText));
+    }
+
     @Override
-    protected void onStart() {
-        super.onStart();
-
-
+    protected void onResume() {
+        super.onResume();
 
         disposableList.add(ChatSDK.events().sourceOnMain()
                 .filter(NetworkEvent.filterType(EventType.MessageAdded, EventType.ThreadReadReceiptUpdated, EventType.MessageRemoved))
@@ -418,35 +440,6 @@ public class ChatActivity extends BaseActivity implements TextInputDelegate, Cha
                         setSubtitleText(typingText);
                     }
                 }));
-    }
-
-    protected void setSubtitleText(String text) {
-        if(StringChecker.isNullOrEmpty(text)) {
-            if(thread.typeIs(ThreadType.Private1to1)) {
-                text = getString(R.string.tap_here_for_contact_info);
-            }
-            else {
-                text = "";
-                for(User u : thread.getUsers()) {
-                    if(!u.isMe()) {
-                        String name = u.getName();
-                        if (name != null && name.length() > 0) {
-                            text += name + ", ";
-                        }
-                    }
-                }
-                if(text.length() > 0) {
-                    text = text.substring(0, text.length() - 2);
-                }
-            }
-        }
-        final String finalText = text;
-        new Handler(getMainLooper()).post(() -> subtitleTextView.setText(finalText));
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
 
         removeUserFromChatOnExit = true;
 


### PR DESCRIPTION
We realised that when in one concrete thread, if you open a push notification to a different thread, you enter that other thread but the messages are not being updated correctly (because it is filtering the threadId with this
`filter(NetworkEvent.filterThreadEntityID(thread.getEntityID()))`
, which is correct).

We saw that the subscribing to the different network events is being done in the onStart lifecycle callback, but we think that should be done in the onResume one, this way, it gets fixed.

If there are some side effects we are not seeing or there is a better way to do it, we are more than happy to know.

Thanks!