### PR TITLE
Only allow to add members to Private1to1 and PrivateGroup threads

### DIFF
--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/ChatActivity.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/chat/ChatActivity.java
@@ -579,7 +579,7 @@ public class ChatActivity extends BaseActivity implements TextInputDelegate, Cha
             return super.onCreateOptionsMenu(menu);
 
         // Adding the add user option only if group chat is enabled.
-        if (ChatSDK.config().groupsEnabled && thread.typeIs(ThreadType.Group)) {
+        if (ChatSDK.config().groupsEnabled && thread.typeIs(ThreadType.Private)) {
             MenuItem item = menu.add(Menu.NONE, R.id.action_chat_sdk_add, 10, getString(R.string.chat_activity_show_users_item_text));
             item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
             item.setIcon(R.drawable.ic_plus);


### PR DESCRIPTION
Public group threads will automatically add/remove members so there is no need for the add button