### PR TITLE
Do not logging in non-debug build types

### DIFF
--- a/chat-sdk-core/src/main/java/co/chatsdk/core/session/ChatSDK.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/session/ChatSDK.java
@@ -95,12 +95,9 @@ public class ChatSDK {
         // Monitor the app so if it goes into the background we know
         AppBackgroundMonitor.shared().setEnabled(true);
 
-//        if (debug) {
-        // TODO: Update this
+        if (config().debug) {
             Timber.plant(new Timber.DebugTree());
-//        } else {
-//            Timber.plant(new Timber.Tree());
-//        }
+        }
 
         return shared();
     }


### PR DESCRIPTION
As recommended by [Google](https://developer.android.com/studio/publish/preparing#publishing-configure) and Timber:
> every time you log in production, a puppy dies

