### PR TITLE
Empty private messages are now rended visible

### DIFF
--- a/app/src/main/java/co/chatsdk/android/app/AppObj.java
+++ b/app/src/main/java/co/chatsdk/android/app/AppObj.java
@@ -25,10 +25,11 @@ public class AppObj extends MultiDexApplication {
 
         Configuration.Builder config = new Configuration.Builder(context);
 //        builder.firebaseRootPath("firebase_v4_web_new_4");
-        config.firebaseRootPath("18_12_bug");
+        config.firebaseRootPath("19_01");
         config.googleMaps("AIzaSyCwwtZrlY9Rl8paM0R6iDNBEit_iexQ1aE");
-        config.publicRoomCreationEnabled(false);
+        config.publicRoomCreationEnabled(true);
         config.pushNotificationSound("default");
+        config.setShowEmptyChats(true);
 //        config.pushNotificationsForPublicChatRoomsEnabled(true);
 
         try {


### PR DESCRIPTION
Empty private chats are now shown in the list of private chats. THe line ```config.setShowEmptyChats(true);``` was added to the App Obj file. The creation of public chat room was also enabled.