### PR TITLE
Add addTab and removeTab methods to InterfaceAdapter to match iOS version

### DIFF
--- a/chat-sdk-core/src/main/java/co/chatsdk/core/Tab.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/Tab.java
@@ -1,6 +1,8 @@
 package co.chatsdk.core;
 
 
+import android.content.Context;
+
 import androidx.fragment.app.Fragment;
 
 import co.chatsdk.core.session.ChatSDK;
@@ -15,16 +17,18 @@ public class Tab {
     public String title;
     public int icon;
 
-    public Tab (int titleResource, int icon, Fragment fragment) {
-        this.fragment = fragment;
-        this.title = ChatSDK.shared().context().getString(titleResource);
-        this.icon = icon;
-    }
-
     public Tab (String title, int icon, Fragment fragment) {
         this.fragment = fragment;
         this.title = title;
         this.icon = icon;
+    }
+
+    public Tab (Context context, int titleResource, int icon, Fragment fragment) {
+        this(context.getString(titleResource), icon, fragment);
+    }
+
+    public Tab (int titleResource, int icon, Fragment fragment) {
+        this(ChatSDK.shared().context(), titleResource, icon, fragment);
     }
 
 }

--- a/chat-sdk-core/src/main/java/co/chatsdk/core/Tab.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/Tab.java
@@ -23,12 +23,12 @@ public class Tab {
         this.icon = icon;
     }
 
-    public Tab (Context context, int titleResource, int icon, Fragment fragment) {
+    public Tab (int titleResource, int icon, Fragment fragment, Context context) {
         this(context.getString(titleResource), icon, fragment);
     }
 
     public Tab (int titleResource, int icon, Fragment fragment) {
-        this(ChatSDK.shared().context(), titleResource, icon, fragment);
+        this(titleResource, icon, fragment, ChatSDK.shared().context());
     }
 
 }

--- a/chat-sdk-core/src/main/java/co/chatsdk/core/interfaces/InterfaceAdapter.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/interfaces/InterfaceAdapter.java
@@ -37,6 +37,7 @@ public interface InterfaceAdapter {
     Class getProfileActivity();
 
     List<Tab> defaultTabs ();
+    List<Tab> tabs();
 
     Tab privateThreadsTab ();
     Tab publicThreadsTab ();
@@ -44,6 +45,14 @@ public interface InterfaceAdapter {
     Tab profileTab ();
 
     Activity profileActivity (User user);
+
+    void addTab(Tab tab);
+    void addTab(int index, Tab tab);
+
+    void addTab(String title, int icon, Fragment fragment);
+    void addTab(int index, String title, int icon, Fragment fragment);
+
+    void removeTab(int index);
 
     void startActivity(Context context, Class activity);
     void startActivity (Context context, Intent intent);

--- a/chat-sdk-core/src/main/java/co/chatsdk/core/interfaces/InterfaceAdapter.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/interfaces/InterfaceAdapter.java
@@ -47,10 +47,10 @@ public interface InterfaceAdapter {
     Activity profileActivity (User user);
 
     void addTab(Tab tab);
-    void addTab(int index, Tab tab);
+    void addTab(Tab tab, int index);
 
     void addTab(String title, int icon, Fragment fragment);
-    void addTab(int index, String title, int icon, Fragment fragment);
+    void addTab(String title, int icon, Fragment fragment, int index);
 
     void removeTab(int index);
 

--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/main/PagerAdapterTabs.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/main/PagerAdapterTabs.java
@@ -26,7 +26,7 @@ public class PagerAdapterTabs extends FragmentPagerAdapter {
 
     public PagerAdapterTabs(FragmentManager fm) {
         super(fm);
-        tabs = ChatSDK.ui().defaultTabs();
+        tabs = ChatSDK.ui().tabs();
     }
 
     public List<Tab> getTabs() {

--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/manager/BaseInterfaceAdapter.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/manager/BaseInterfaceAdapter.java
@@ -2,6 +2,7 @@ package co.chatsdk.ui.manager;
 
 import android.content.Context;
 import android.content.Intent;
+import android.util.SparseArray;
 
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.app.AppCompatActivity;
@@ -65,8 +66,13 @@ public class BaseInterfaceAdapter implements InterfaceAdapter {
     public LocalNotificationHandler localNotificationHandler;
     public NotificationDisplayHandler notificationDisplayHandler;
 
-    public BaseInterfaceAdapter (Context context) {
+    private SparseArray<Tab> additionalTabs = new SparseArray<>();
+    private Tab privateThreadsTab;
+    private Tab publicThreadsTab;
+    private Tab contactsTab;
+    private Tab profileTab;
 
+    public BaseInterfaceAdapter (Context context) {
         DiskCacheConfig diskCacheConfig = DiskCacheConfig
                 .newBuilder(context)
                 .setMaxCacheSizeOnVeryLowDiskSpace(10 * ByteConstants.MB)
@@ -90,38 +96,75 @@ public class BaseInterfaceAdapter implements InterfaceAdapter {
         setMessageHandler(new ImageMessageDisplayHandler(), new MessageType(MessageType.Image));
         setMessageHandler(new LocationMessageDisplayHandler(), new MessageType(MessageType.Location));
 
+        privateThreadsTab = new Tab(context.getString(R.string.conversations), R.drawable.ic_action_private, privateThreadsFragment());
+        publicThreadsTab = new Tab(context.getString(R.string.chat_rooms), R.drawable.ic_action_public, publicThreadsFragment());
+        contactsTab = new Tab(context.getString(R.string.contacts), R.drawable.ic_action_contacts, contactsFragment());
+        profileTab = new Tab (context.getString(R.string.profile), R.drawable.ic_action_user, profileFragment(null));
     }
 
     @Override
     public List<Tab> defaultTabs() {
-
         ArrayList<Tab> tabs = new ArrayList<>();
         tabs.add(privateThreadsTab());
         tabs.add(publicThreadsTab());
         tabs.add(contactsTab());
         tabs.add(profileTab());
-
         return tabs;
     }
 
     @Override
+    public List<Tab> tabs() {
+        List<Tab> tabs = defaultTabs();
+        for (int i = 0; i < additionalTabs.size(); i++) {
+            int key = additionalTabs.keyAt(i);
+            tabs.add(key, additionalTabs.get(key));
+        }
+        return tabs;
+    }
+
+    @Override
+    public void addTab(Tab tab) {
+        additionalTabs.append(tabs().size(), tab);
+    }
+
+    @Override
+    public void addTab(int index, Tab tab) {
+        additionalTabs.append(index, tab);
+    }
+
+    @Override
+    public void addTab(String title, int icon, Fragment fragment) {
+        addTab(new Tab(title, icon, fragment));
+    }
+
+    @Override
+    public void addTab(int index, String title, int icon, Fragment fragment) {
+        addTab(index, new Tab(title, icon, fragment));
+    }
+
+    @Override
+    public void removeTab(int index) {
+        additionalTabs.remove(index);
+    }
+
+    @Override
     public Tab privateThreadsTab() {
-        return new Tab(R.string.conversations, R.drawable.ic_action_private, privateThreadsFragment());
+        return privateThreadsTab;
     }
 
     @Override
     public Tab publicThreadsTab() {
-        return new Tab(R.string.chat_rooms, R.drawable.ic_action_public, publicThreadsFragment());
+        return publicThreadsTab;
     }
 
     @Override
     public Tab contactsTab() {
-        return new Tab(R.string.contacts, R.drawable.ic_action_contacts, contactsFragment());
+        return contactsTab;
     }
 
     @Override
     public Tab profileTab() {
-        return new Tab (R.string.profile, R.drawable.ic_action_user, profileFragment(null));
+        return profileTab;
     }
 
     @Override

--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/manager/BaseInterfaceAdapter.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/manager/BaseInterfaceAdapter.java
@@ -128,7 +128,7 @@ public class BaseInterfaceAdapter implements InterfaceAdapter {
     }
 
     @Override
-    public void addTab(int index, Tab tab) {
+    public void addTab(Tab tab, int index) {
         additionalTabs.append(index, tab);
     }
 
@@ -138,8 +138,8 @@ public class BaseInterfaceAdapter implements InterfaceAdapter {
     }
 
     @Override
-    public void addTab(int index, String title, int icon, Fragment fragment) {
-        addTab(index, new Tab(title, icon, fragment));
+    public void addTab(String title, int icon, Fragment fragment, int index) {
+        addTab(new Tab(title, icon, fragment), index);
     }
 
     @Override


### PR DESCRIPTION
Add a four new`addTab` methods and one `removeTab` method to add/remove tabs to a new `additionalTabs` array:
1. `void addTab(Tab tab)`
2. `void addTab(int index, Tab tab)`
3. `void addTab(String title, int icon, Fragment fragment)`
4.  `void addTab(int index, String title, int icon, Fragment fragment)`
5. `void removeTab(int index)`

Add `tabs()` method which returns a combination of `defaultTabs()` and `additionalTabs` sorted by their index.

---

Add new constructor to `Tab` class in case you need to create a tab before ChatSDK is initialized where `ChatSDK.shared().context()` would return `null`:
`Tab (Context context, int titleResource, int icon, Fragment fragment)`

