### PR TITLE
Fix usage of unsupported "DROP COLUMN" in MigrationV5

### DIFF
--- a/chat-sdk-core/src/main/java/co/chatsdk/core/dao/DatabaseUpgradeHelper.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/dao/DatabaseUpgradeHelper.java
@@ -37,7 +37,6 @@ public class DatabaseUpgradeHelper extends DaoMaster.OpenHelper {
         migrations.add(new MigrationV2());
         migrations.add(new MigrationV3());
         migrations.add(new MigrationV4());
-        migrations.add(new MigrationV5());
         migrations.add(new MigrationV6());
         migrations.add(new MigrationV7());
 
@@ -94,20 +93,6 @@ public class DatabaseUpgradeHelper extends DaoMaster.OpenHelper {
         public void runMigration(Database db) {
             //Adding new table
             db.execSQL("ALTER TABLE " + UserDao.TABLENAME + " DROP COLUMN " + "LAST_UPDATED");
-        }
-    }
-
-    private static class MigrationV5 implements Migration {
-
-        @Override
-        public Integer getVersion() {
-            return 5;
-        }
-
-        @Override
-        public void runMigration(Database db) {
-            //Adding new table
-            db.execSQL("ALTER TABLE " + MessageDao.TABLENAME + " DROP COLUMN " + "TEXT");
         }
     }
 


### PR DESCRIPTION
Fixes #501 

As the documentation specifies, SQLite does not support `DROP COLUMN`
https://www.sqlite.org/faq.html#q11

> SQLite has limited ALTER TABLE support that you can use to add a column to the end of a table or to change the name of a table. If you want to make more complex changes in the structure of a table, you will have to recreate the table. You can save existing data to a temporary table, drop the old table, create the new table, then copy the data back in from the temporary table.

Migration removed as it doesn't add any value to remove the column, and the messages will be removed in `MigrationV6`