### PR TITLE
Fix NPE in MigrationV6

### DIFF
--- a/chat-sdk-core/src/main/java/co/chatsdk/core/dao/DatabaseUpgradeHelper.java
+++ b/chat-sdk-core/src/main/java/co/chatsdk/core/dao/DatabaseUpgradeHelper.java
@@ -126,13 +126,9 @@ public class DatabaseUpgradeHelper extends DaoMaster.OpenHelper {
             ReadReceiptUserLinkDao.dropTable(db, false);
             ReadReceiptUserLinkDao.createTable(db, true);
 
-//            db.execSQL("ALTER TABLE " + ReadReceiptUserLinkDao.TABLENAME + " DROP COLUMN " + "READRECEIPTID");
-
             // Clear down the message database and re synchronize
-            List<Message> messages = DaoCore.fetchEntitiesOfClass(Message.class);
-            for (Message m : messages) {
-                DaoCore.deleteEntity(m);
-            }
+            MessageDao.dropTable(db, false);
+            MessageDao.createTable(db, true);
         }
     }
 


### PR DESCRIPTION
Fixes #502 

MigrationV6 tries to use a null daoSession through DaoCore.fetchEntitiesOfClass, but the daoSession is only initialised in DaoCore.openDB after the migrations have finished.

Recreating the table is the best approach to clear the table and fix the schema after the `TEXT` column removal in f33bba9e9b3e4c6d907c0e153e22ef18501f7332