### PR TITLE
Fix bad end of receiver tag in chat-sdk-firebase-push's AndroidManifest

### DIFF
--- a/chat-sdk-firebase-push/src/main/AndroidManifest.xml
+++ b/chat-sdk-firebase-push/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
 
         <receiver
             android:name="co.chatsdk.firebase.push.DefaultBroadcastReceiver"
-            android:permission="com.google.android.c2dm.permission.SEND">
+            android:permission="com.google.android.c2dm.permission.SEND"
             android:enabled="true"
             android:exported="true">
             <intent-filter>


### PR DESCRIPTION
Fixes a mistaken ending tag in the chat-sdk-firebase-push module AndroidManifest.