### PR TITLE
Search text final space character removal

### DIFF
--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/search/SearchActivity.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/search/SearchActivity.java
@@ -228,7 +228,14 @@ public class SearchActivity extends BaseActivity {
 
     public String searchText () {
         if (searchEditText.getText() != null) {
-            return searchEditText.getText().toString();
+//Here we determine if the last character in the search text is a space. If so we delete that space and run the search without it.
+            String searchTextString = searchEditText.getText().toString();
+            char lastCharacterInText = searchTextString.charAt(searchTextString.length() - 1);
+            if (lastCharacterInText == ' ') {
+                searchTextString = searchTextString.substring(0, searchTextString.length() - 1);
+                return searchTextString;
+            }
+            return searchTextString;
         }
         return "";
     }

--- a/chat-sdk-ui/src/main/java/co/chatsdk/ui/search/SearchActivity.java
+++ b/chat-sdk-ui/src/main/java/co/chatsdk/ui/search/SearchActivity.java
@@ -228,14 +228,8 @@ public class SearchActivity extends BaseActivity {
 
     public String searchText () {
         if (searchEditText.getText() != null) {
-//Here we determine if the last character in the search text is a space. If so we delete that space and run the search without it.
-            String searchTextString = searchEditText.getText().toString();
-            char lastCharacterInText = searchTextString.charAt(searchTextString.length() - 1);
-            if (lastCharacterInText == ' ') {
-                searchTextString = searchTextString.substring(0, searchTextString.length() - 1);
-                return searchTextString;
-            }
-            return searchTextString;
+//Here we trim the leading and trailing spaces around the search term.
+            return searchEditText.getText().toString().trim();
         }
         return "";
     }


### PR DESCRIPTION
I changed the way the search text is processed so if the last character is a space, the space will be removed from the search text string before the search is conducted. This will ensure that any errant spaces at the ends of search strings do not end up causing the search to miss the intened search term. This is only done once though. Multiple spaces at the end of the search string will still have this problem. 